### PR TITLE
Revert "Update webservice.md"

### DIFF
--- a/informacao-tecnica/incm/webservice.md
+++ b/informacao-tecnica/incm/webservice.md
@@ -8,7 +8,7 @@ Nesta página encontra os métodos que o webservice disponibiliza para todos os 
 
 {% file src="../../.gitbook/assets/public \(1\).wsdl" caption="public.wdsl \(testes\)" %}
 
-{% file src="https://www-tst.cryptosaft.incm.pt/images/INCM%20-%20CryptoSAF-T_Manual_de_Integracao.pdf" caption="Manual de Integração CryptoSAFT" %}
+{% file src="../../.gitbook/assets/incm-cryptosaf-t\_manual\_de\_integracao-1-.pdf" caption="Manual de Integração CryptoSAFT" %}
 
 ## Pedido de Chave \(KeyRequest\) 
 


### PR DESCRIPTION
Reverts assoft-portugal/documentacao-CryptoSAF-T#2

Apresenta um erro de apresentação no gitbook.
Não pode ser indicado um link para fora da repo.